### PR TITLE
Use setarch --addr-no-randomize to fix tests run with address-sanitizer

### DIFF
--- a/srcs/diff_test.sh
+++ b/srcs/diff_test.sh
@@ -36,9 +36,14 @@ diff_test()
 		if [ $(( $k%2 )) -eq 1 ] && ([ $1 == "ft_putchar_fd.c" ] || [ $1 == "ft_putstr_fd.c" ] || [ $1 == "ft_putendl_fd.c" ] || [ $1 == "ft_putnbr_fd.c" ])
 		then
 			#"${PATH_TEST}"/user_exe $k > "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1)/user_output_test${text}$k 2>&1
-			"${PATH_TEST}"/user_exe $k > /dev/null 2> "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
+			# Use `setarch --addr-no-randomize` to address issue with address-sanitizer
+			# and use `$(uname -m)` to be compatible with pre 2.33 version of `setarch` where `arch` argument was required.
+			# See https://github.com/google/sanitizers/issues/856
+			# and https://github.com/0x050f/libft-war-machine/pull/47
+			# for more details.
+			setarch $(uname -m) --addr-no-randomize "${PATH_TEST}"/user_exe $k > /dev/null 2> "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
 		else
-			"${PATH_TEST}"/user_exe $k > "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
+			setarch $(uname -m) --addr-no-randomize "${PATH_TEST}"/user_exe $k > "${PATH_TEST}"/tests/$(echo ${part}tions)/$(echo $1 | cut -d . -f 1 | sed 's/_bonus//g')/user_output_test${text}$k
 		fi
 		SIG=$?
 		if [ $SIG -eq 134 ]


### PR DESCRIPTION
This commit introduces the same change done at [0x050f/libft-war-machine PR#47](https://github.com/0x050f/libft-war-machine/pull/47).

This fixes some issues with the address sanitizers. For more info, check https://github.com/google/sanitizers/issues/856